### PR TITLE
fix: reconnect when CAS released under KEEP_CONNECTION=AUTO

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -132,12 +132,46 @@ func (c *conn) recv() ([]byte, error) {
 }
 
 // sendAndRecv sends data and returns the framed response.
+// Before sending, checks CAS_INFO status and reconnects if the broker
+// has released the CAS process — matching the official CUBRID JDBC
+// driver's UClientSideConnection.checkReconnect().
 func (c *conn) sendAndRecv(data []byte) ([]byte, error) {
-	if err := c.send(data); err != nil {
+	if err := c.checkReconnect(); err != nil {
 		return nil, err
 	}
-	return c.recv()
+	if err := c.send(data); err != nil {
+		return nil, driver.ErrBadConn
+	}
+	resp, err := c.recv()
+	if err != nil {
+		return nil, driver.ErrBadConn
+	}
+	// Update CAS_INFO from the response (first 4 bytes).
+	if len(resp) >= SizeCASInfo {
+		copy(c.casInfo[:], resp[:SizeCASInfo])
+	}
+	return resp, nil
 }
+
+// checkReconnect reconnects when the CAS has been released.
+//
+// The CUBRID broker sets CAS_INFO[0] to INACTIVE (0) when the CAS
+// process is no longer reserved for this client (KEEP_CONNECTION=AUTO).
+// The official JDBC driver checks this before every request and
+// transparently reconnects.
+func (c *conn) checkReconnect() error {
+	if c.closed || c.socket == nil {
+		return driver.ErrBadConn
+	}
+	if c.casInfo[0] == casInfoStatusInactive {
+		c.socket.Close()
+		c.socket = nil
+		return c.connect()
+	}
+	return nil
+}
+
+const casInfoStatusInactive = 0
 
 func namedValuesToValues(args []driver.NamedValue) ([]driver.Value, error) {
 	values := make([]driver.Value, len(args))

--- a/conn.go
+++ b/conn.go
@@ -164,7 +164,7 @@ func (c *conn) checkReconnect() error {
 		return driver.ErrBadConn
 	}
 	if c.casInfo[0] == casInfoStatusInactive {
-		c.socket.Close()
+		_ = c.socket.Close()
 		c.socket = nil
 		return c.connect()
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -87,6 +87,7 @@ func prepareAndExecuteResponsePacket(stmtType byte, totalCount, resultCount, tup
 	body := w.toBytes()
 
 	var casInfo [SizeCASInfo]byte
+	casInfo[0] = 1 // ACTIVE – prevent checkReconnect from triggering
 	header := buildProtocolHeader(len(body), casInfo)
 	packet := make([]byte, 0, len(header)+len(body))
 	packet = append(packet, header...)
@@ -100,6 +101,7 @@ func simpleResponsePacket(code int32) []byte {
 	body := w.toBytes()
 
 	var casInfo [SizeCASInfo]byte
+	casInfo[0] = 1 // ACTIVE – prevent checkReconnect from triggering
 	header := buildProtocolHeader(len(body), casInfo)
 	packet := make([]byte, 0, len(header)+len(body))
 	packet = append(packet, header...)
@@ -114,6 +116,7 @@ func TestQueryContextWorksAndAppliesDeadline(t *testing.T) {
 
 	tracked := &deadlineTrackingConn{Conn: client}
 	c := &conn{socket: tracked, autoCommit: true, protoVer: ProtoVersion}
+	c.casInfo[0] = 1 // ACTIVE – prevent checkReconnect from triggering
 
 	go func() {
 		consumeOneRequest(t, server)
@@ -147,6 +150,7 @@ func TestExecContextWorksWithDML(t *testing.T) {
 
 	tracked := &deadlineTrackingConn{Conn: client}
 	c := &conn{socket: tracked, autoCommit: true, protoVer: ProtoVersion}
+	c.casInfo[0] = 1 // ACTIVE – prevent checkReconnect from triggering
 
 	go func() {
 		consumeOneRequest(t, server)
@@ -194,6 +198,7 @@ func TestExecContextExpiredContextReturnsImmediately(t *testing.T) {
 
 	tracked := &deadlineTrackingConn{Conn: client}
 	c := &conn{socket: tracked, autoCommit: true, protoVer: ProtoVersion}
+	c.casInfo[0] = 1 // ACTIVE – prevent checkReconnect from triggering
 
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 	defer cancel()
@@ -213,6 +218,7 @@ func TestQueryContextCancellationInterruptsInflightOperation(t *testing.T) {
 
 	tracked := &deadlineTrackingConn{Conn: client}
 	c := &conn{socket: tracked, autoCommit: true, protoVer: ProtoVersion}
+	c.casInfo[0] = 1 // ACTIVE – prevent checkReconnect from triggering
 
 	requestRead := make(chan struct{})
 	go func() {


### PR DESCRIPTION
## Summary
- Add `checkReconnect()` that inspects `CAS_INFO[0]` status before each request and transparently reconnects when the broker has released the CAS process (`KEEP_CONNECTION=AUTO`, the default)
- Update `CAS_INFO` from every response in `sendAndRecv()` (was missing)
- Return `driver.ErrBadConn` on socket errors so `database/sql` can retry with a fresh connection

## Root Cause
The CUBRID broker may release the CAS process after a transaction commit when `KEEP_CONNECTION=AUTO`. This sets `CAS_INFO[0]` to `INACTIVE` (0). Subsequent requests on the dead socket cause `EOF` / broken pipe.

## Approach
Ported the same reconnection pattern used by the official CUBRID JDBC driver (`UClientSideConnection.checkReconnect()`). The same fix was applied to:
- Python driver: cubrid-labs/pycubrid#24
- Node.js driver: cubrid-labs/cubrid-client#16

## Test plan
- [x] DDL → DML sequence (`autocommit=true`) — **failed before fix, passes after**
- [x] DDL → DML sequence (`autocommit=false`) — passes
- [x] `go build ./...` — no compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)